### PR TITLE
Add testID and accessibilityLabel to info list items

### DIFF
--- a/components/src/core/info-list-item/info-list-item.tsx
+++ b/components/src/core/info-list-item/info-list-item.tsx
@@ -369,6 +369,9 @@ export const InfoListItem: React.FC<InfoListItemProps> = (props) => {
 
     return (
         <TouchableOpacity
+            accessible={true}
+            testID={`list-item-${title.replace(/\s+/g, '-').toLowerCase()}`}
+            accessibilityLabel={`list-item-${title.replace(/\s+/g, '-').toLowerCase()}`}
             onPress={onPress}
             style={[defaultStyles.root, styles.root, style]}
             disabled={!onPress}


### PR DESCRIPTION
- Add testID and accessibilityLabel, in the form `list-item-example`, to info list items so they can be easily accessed in UI and E2E tests.