### PR TITLE
Make header more accessible for testing

### DIFF
--- a/components/src/core/header/header.tsx
+++ b/components/src/core/header/header.tsx
@@ -686,7 +686,7 @@ export const Header: React.FC<HeaderProps> = (props) => {
         <>
             <StatusBar barStyle={statusBarStyle()} />
             <TouchableWithoutFeedback
-                accessibilty={false}
+                accessible={false}
                 onPress={(): void => onPress()}
                 disabled={!expandable || searching}
                 {...viewProps}

--- a/components/src/core/header/header.tsx
+++ b/components/src/core/header/header.tsx
@@ -686,6 +686,7 @@ export const Header: React.FC<HeaderProps> = (props) => {
         <>
             <StatusBar barStyle={statusBarStyle()} />
             <TouchableWithoutFeedback
+                accessibilty={false}
                 onPress={(): void => onPress()}
                 disabled={!expandable || searching}
                 {...viewProps}

--- a/components/src/core/header/headerActionItems.tsx
+++ b/components/src/core/header/headerActionItems.tsx
@@ -93,7 +93,7 @@ export const HeaderActionItems: React.FC<ActionItemProps> = (props) => {
                             <View
                                 key={`action_${index}`}
                                 testID={`header-action-item${index}`}
-                                accessibiltyLabel={`header-action-item${index}`}
+                                accessibilityLabel={`header-action-item${index}`}
                                 style={[
                                     defaultStyles.component,
                                     actionItem.width ? { width: actionItem.width } : {},
@@ -108,7 +108,7 @@ export const HeaderActionItems: React.FC<ActionItemProps> = (props) => {
                         <TouchableOpacity
                             key={`action_${index}`}
                             testID={`header-action-item${index}`}
-                            accessibiltyLabel={`header-action-item${index}`}
+                            accessibilityLabel={`header-action-item${index}`}
                             onPress={actionItem.onPress}
                             style={[defaultStyles.actionItem, styles.actionItem]}
                         >

--- a/components/src/core/header/headerActionItems.tsx
+++ b/components/src/core/header/headerActionItems.tsx
@@ -93,6 +93,7 @@ export const HeaderActionItems: React.FC<ActionItemProps> = (props) => {
                             <View
                                 key={`action_${index}`}
                                 testID={`header-action-item${index}`}
+                                accessibiltyLabel={`header-action-item${index}`}
                                 style={[
                                     defaultStyles.component,
                                     actionItem.width ? { width: actionItem.width } : {},
@@ -107,6 +108,7 @@ export const HeaderActionItems: React.FC<ActionItemProps> = (props) => {
                         <TouchableOpacity
                             key={`action_${index}`}
                             testID={`header-action-item${index}`}
+                            accessibiltyLabel={`header-action-item${index}`}
                             onPress={actionItem.onPress}
                             style={[defaultStyles.actionItem, styles.actionItem]}
                         >

--- a/components/src/core/header/headerNavigationIcon.tsx
+++ b/components/src/core/header/headerNavigationIcon.tsx
@@ -50,6 +50,7 @@ export const HeaderNavigationIcon: React.FC<HeaderNavigationProps> = (props) => 
         return (
             <TouchableOpacity
                 testID={'header-search-close'}
+                accessibiltyLabel={'header-search-close'}
                 onPress={onClose ? (): void => onClose() : undefined}
                 style={[defaultStyles.navigation, style]}
             >
@@ -67,6 +68,7 @@ export const HeaderNavigationIcon: React.FC<HeaderNavigationProps> = (props) => 
         return (
             <TouchableOpacity
                 testID={'header-navigation'}
+                accessibiltyLabel={'header-navigation'}
                 onPress={onPress}
                 style={[defaultStyles.navigation, style]}
                 disabled={!onPress}

--- a/components/src/core/header/headerNavigationIcon.tsx
+++ b/components/src/core/header/headerNavigationIcon.tsx
@@ -50,7 +50,7 @@ export const HeaderNavigationIcon: React.FC<HeaderNavigationProps> = (props) => 
         return (
             <TouchableOpacity
                 testID={'header-search-close'}
-                accessibiltyLabel={'header-search-close'}
+                accessibilityLabel={'header-search-close'}
                 onPress={onClose ? (): void => onClose() : undefined}
                 style={[defaultStyles.navigation, style]}
             >
@@ -68,7 +68,7 @@ export const HeaderNavigationIcon: React.FC<HeaderNavigationProps> = (props) => 
         return (
             <TouchableOpacity
                 testID={'header-navigation'}
-                accessibiltyLabel={'header-navigation'}
+                accessibilityLabel={'header-navigation'}
                 onPress={onPress}
                 style={[defaultStyles.navigation, style]}
                 disabled={!onPress}


### PR DESCRIPTION
I'm opening one more PR for some testing-related accessibility changes we need for our E2E tests with Appium. This one targets the Header component. The top-level TouchableWithoutFeedback must not be accessible itself, or its children become inaccessible for iOS (so we can't tap on the header's action items, etc.). Additionally, we need accessibilityLabels on these inside elements to make them reachable for Android.

Here's some further reading regarding accessibility and iOS: https://github.com/appium/appium/issues/10654 and https://github.com/appium/java-client/issues/666