### PR TITLE
BLUI-3219 Fix Header component default background size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Change Log
 
-## v6.1.0 (Unreleased)
+## v6.0.3 (Unreleased)
 
 ### Added
 
 -   Added `testID` and `accessibilityLabel` to `<InfoListItem>`, `<Header>`, `<HeaderActionItems>`, and `<HeaderNavigationIcon>` for easy access in UI and E2E tests.
+
+### Fixed
+
+-   Issue with `<Header>` default backgroundImage size ([#228](https://github.com/brightlayer-ui/react-native-component-library/issues/228)).
 
 ## v6.0.2 (December 17, 2021)
 

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@brightlayer-ui/react-native-components",
-    "version": "6.1.0-beta.1",
+    "version": "6.0.3-beta.0",
     "author": "brightlayer-ui <brightlayer-ui@eaton.com>",
     "description": "Reusable React Native components for Brightlayer UI applications",
     "repository": {

--- a/components/src/core/header/headerBackgroundImage.tsx
+++ b/components/src/core/header/headerBackgroundImage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Animated, ImageProps, ImageSourcePropType, StyleSheet, Text } from 'react-native';
+import { Animated, ImageProps, ImageSourcePropType, StyleSheet } from 'react-native';
 import { useSearch } from './contexts/SearchContextProvider';
 import { useHeaderHeight } from './contexts/HeaderHeightContextProvider';
 import { useHeaderDimensions } from '../hooks/useHeaderDimensions';

--- a/components/src/core/header/headerBackgroundImage.tsx
+++ b/components/src/core/header/headerBackgroundImage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Animated, ImageProps, ImageSourcePropType, StyleSheet } from 'react-native';
+import { Animated, ImageProps, ImageSourcePropType, StyleSheet, Text } from 'react-native';
 import { useSearch } from './contexts/SearchContextProvider';
 import { useHeaderHeight } from './contexts/HeaderHeightContextProvider';
 import { useHeaderDimensions } from '../hooks/useHeaderDimensions';
@@ -12,6 +12,7 @@ const defaultStyles = StyleSheet.create({
         right: 0,
         bottom: 0,
         resizeMode: 'cover',
+        width: '100%',
     },
 });
 type HeaderBackgroundProps = Omit<ImageProps, 'source'> & {


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #228 / BLUI-3219.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Fix Header component default background size

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
![Simulator Screen Shot - iPhone 12 - 2022-07-13 at 14 44 30](https://user-images.githubusercontent.com/13989985/178819306-75f11b8a-bc04-443c-a4bd-c88788527815.png)

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- `git clone git@github.com:brightlayer-ui/react-native-component-library.git`
- yarn start:showcase
- navigate to Header "with background image" and observe being able to see the full farm image

**note: the storybook app was not updating for me locally so I had to bundle the components and manually move them into the react-native-design-pattern repo to test via the "collapsible appbar" design pattern. 
