### PR TITLE
Update styling around header text clipping

### DIFF
--- a/components/src/core/header/header.tsx
+++ b/components/src/core/header/header.tsx
@@ -59,7 +59,6 @@ const headerStyles = (
         },
         content: {
             flex: 1,
-            paddingVertical: 16 * fontScale,
             paddingHorizontal: 16,
             flexDirection: 'row',
             minHeight: 56 * fontScale,
@@ -527,30 +526,30 @@ export const Header: React.FC<HeaderProps> = (props) => {
     );
 
     // Returns the interpolated bottom padding of the Header text elements
-    const contentStyle = useCallback((): Array<Record<string, any>> => {
-        const contractedPadding = (subtitle && !searching ? 12 : 16) * fontScale;
-        return [
+    const contentStyle = useCallback(
+        (): Array<Record<string, any>> => [
             searching ? defaultStyles.search : defaultStyles.content,
             searching
                 ? {}
                 : {
                       paddingBottom: (useStaticHeight ? staticHeaderHeight : dynamicHeaderHeight).interpolate({
                           inputRange: [collapsedHeight, expandedHeight],
-                          outputRange: [contractedPadding, 28],
+                          outputRange: [0, 28],
                           extrapolate: 'clamp',
                       }),
                   },
-        ];
-    }, [
-        subtitle,
-        searching,
-        dynamicHeaderHeight,
-        defaultStyles,
-        useStaticHeight,
-        staticHeaderHeight,
-        collapsedHeight,
-        expandedHeight,
-    ]);
+        ],
+        [
+            subtitle,
+            searching,
+            dynamicHeaderHeight,
+            defaultStyles,
+            useStaticHeight,
+            staticHeaderHeight,
+            collapsedHeight,
+            expandedHeight,
+        ]
+    );
 
     /* CALLBACK FUNCTIONS */
 

--- a/components/src/core/header/headerContent.tsx
+++ b/components/src/core/header/headerContent.tsx
@@ -64,11 +64,6 @@ const HeaderTitle: React.FC<HeaderTitleProps> = (props) => {
     const getTitleStyle = useCallback(
         () => ({
             color: textColor,
-            lineHeight: headerHeight.interpolate({
-                inputRange: [REGULAR_HEIGHT, EXTENDED_HEIGHT],
-                outputRange: [24, 36],
-                extrapolate: 'clamp',
-            }),
             fontFamily: theme.fonts.medium.fontFamily,
             fontSize: headerHeight.interpolate({
                 inputRange: [REGULAR_HEIGHT, EXTENDED_HEIGHT],
@@ -127,7 +122,6 @@ const HeaderSubtitle: React.FC<HeaderSubtitleProps> = (props) => {
     const getSubtitleStyle = useCallback(
         () => ({
             color: textColor,
-            lineHeight: washingtonStyle ? 18 : 16,
             fontFamily: washingtonStyle ? theme.fonts.light.fontFamily : theme.fonts.regular.fontFamily,
             fontSize: washingtonStyle ? 18 : 16,
             writingDirection: I18nManager.isRTL ? 'rtl' : ('ltr' as WritingDirection),
@@ -175,15 +169,15 @@ const HeaderInfo: React.FC<HeaderInfoProps> = (props) => {
     const { info, theme, style } = props;
     const { color: textColor } = useColor();
     const { headerHeight } = useHeaderHeight();
-
+    const fontScale = PixelRatio.getFontScale();
     const { REGULAR_HEIGHT, EXTENDED_HEIGHT } = useHeaderDimensions();
 
     const getInfoStyle = useCallback(
         () => ({
             color: textColor,
-            lineHeight: headerHeight.interpolate({
+            marginTop: headerHeight.interpolate({
                 inputRange: [REGULAR_HEIGHT, EXTENDED_HEIGHT],
-                outputRange: [0.1, 20 * 1.05], // Avoid clipping top of CAP letters
+                outputRange: [-2 * fontScale, 0],
                 extrapolate: 'clamp',
             }),
             opacity: headerHeight.interpolate({
@@ -200,7 +194,7 @@ const HeaderInfo: React.FC<HeaderInfoProps> = (props) => {
             writingDirection: I18nManager.isRTL ? 'rtl' : ('ltr' as WritingDirection),
             textAlign: Platform.OS === 'android' ? 'left' : ('auto' as TextAlign),
         }),
-        [textColor, theme, headerHeight, REGULAR_HEIGHT, EXTENDED_HEIGHT]
+        [textColor, theme, headerHeight, REGULAR_HEIGHT, EXTENDED_HEIGHT, fontScale]
     );
 
     if (info) {
@@ -377,7 +371,7 @@ export const HeaderContent: React.FC<HeaderContentProps> = (props) => {
                               outputRange: [getActionPanelWidth(), 0],
                               extrapolate: 'clamp',
                           }),
-                          marginTop: subtitle && title ? 10 * fontScale : 0,
+                          marginBottom: subtitle && title ? 5 * fontScale : 15 * fontScale,
                       },
                 styles.root,
             ]}

--- a/components/src/core/header/headerNavigationIcon.tsx
+++ b/components/src/core/header/headerNavigationIcon.tsx
@@ -14,10 +14,11 @@ const makeStyles = (): StyleSheet.NamedStyles<{
     const fontScale = PixelRatio.getFontScale();
     return StyleSheet.create({
         navigation: {
-            marginRight: 24,
             height: 40 * fontScale,
             width: 40 * fontScale,
-            margin: -8 * fontScale,
+            marginLeft: -8 * fontScale,
+            marginRight: 24,
+            marginTop: 8 * fontScale,
             padding: 8 * fontScale,
         },
         flipIcon: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -268,9 +268,9 @@ json-parse-helpfulerror@^1.0.2:
   dependencies:
     jju "^1.1.0"
 
-"license-checker@git+https://github.com/mwittig/license-checker.git#d546e3f738e14c62e732346fa355162d46700893":
+"license-checker@git+https://github.com/mwittig/license-checker#d546e3f738e14c62e732346fa355162d46700893":
   version "1.0.0"
-  resolved "git+https://github.com/mwittig/license-checker.git#d546e3f738e14c62e732346fa355162d46700893"
+  resolved "git+https://github.com/mwittig/license-checker#d546e3f738e14c62e732346fa355162d46700893"
   dependencies:
     chalk "~0.5.1"
     mkdirp "^0.3.5"


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Remove all the lineHeight logic (the default behavior is better)
- Adjust the spacing around the header content elements using margin bottom instead of padding (padding was causing overflow clipping)