### PR TITLE
Fix mobile stepper default fill color for dark theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Change Log
 
-## v6.1.0 (Unreleased)
+## v6.0.3 (Unreleased)
 
 ### Added
 
 -   Added `testID` and `accessibilityLabel` to `<InfoListItem>`, `<Header>`, `<HeaderActionItems>`, and `<HeaderNavigationIcon>` for easy access in UI and E2E tests.
+
+### Fixed
+
+-   Issue with `<MobileStepper>` default dark theme fill color ([#276](https://github.com/brightlayer-ui/react-native-component-library/issues/276)).
 
 ## v6.0.2 (December 17, 2021)
 

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@brightlayer-ui/react-native-components",
-    "version": "6.1.0-beta.1",
+    "version": "6.0.3-beta.1",
     "author": "brightlayer-ui <brightlayer-ui@eaton.com>",
     "description": "Reusable React Native components for Brightlayer UI applications",
     "repository": {

--- a/components/src/core/mobile-stepper/mobile-stepper.tsx
+++ b/components/src/core/mobile-stepper/mobile-stepper.tsx
@@ -39,7 +39,7 @@ const makeStyles = (
             backgroundColor: props.inactiveColor || (theme.dark ? theme.colors.disabled : Colors.gray[200]),
         },
         filled: {
-            backgroundColor: props.activeColor || getPrimary500(theme) || theme.colors.primary,
+            backgroundColor: props.activeColor || theme.colors.primary,
         },
         progressBar: {},
         text: {},


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #276 / BLUI-3311.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Fix mobile stepper default fill color for dark theme

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
![simulator_screenshot_3B9CB440-E5AC-4CC7-9C31-F4E7C9A8717C](https://user-images.githubusercontent.com/13989985/179261166-e8218867-c4a7-4463-be7f-952fce01fa24.png)


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- `git clone git@github.com:brightlayer-ui/react-native-component-library.git`
- `git checkout feature/BLUI-3311-mobile-stepper-dark-theme-fill-bug`
- update app to use dark theme `blueDark`
- yarn start:showcase
- scroll down to mobile stepper example and observe proper coloring of active step
