### PR TITLE
BLUI-3310 Fix usermenu within a header rendering on multiple lines bug

### DIFF
--- a/demos/storybook/storybook/stories/user-menu.tsx
+++ b/demos/storybook/storybook/stories/user-menu.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react-native';
-import { Image, View } from 'react-native';
+import { Image, View, StyleSheet } from 'react-native';
 import { Header, InfoListItemProps, UserMenu } from '@pxblue/react-native-components';
 import { text, withKnobs, color, select } from '@storybook/addon-knobs';
 import * as Colors from '@pxblue/colors';
@@ -10,6 +10,12 @@ const VpnKeyIcon: IconFamily = { name: 'vpn-key' };
 const SettingsIcon: IconFamily = { name: 'settings' };
 const ExitToAppIcon: IconFamily = { name: 'exit-to-app' };
 const avatarTestImage = require('../assets/test-avatar.png');
+
+const customStyles = StyleSheet.create({
+    root: {
+        maxHeight: 56,
+    },
+});
 
 const menuItems: InfoListItemProps[] = [
     { title: 'Change Password', icon: VpnKeyIcon },
@@ -127,6 +133,7 @@ storiesOf('UserMenu', module)
         <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
             <Header
                 title={'Title'}
+                styles={{ root: customStyles.root }}
                 actionItems={[
                     {
                         component: (


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #234 / BLUI-3310.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Fix usermenu within a header rendering on multiple lines bug

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
![Simulator Screen Shot - iPhone 12 - 2022-07-15 at 13 43 44](https://user-images.githubusercontent.com/13989985/179281386-0f7c59d6-f3cd-4a3b-91d6-9c7745dc4bf9.png)

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
#### To Test:
- `git clone git@github.com:brightlayer-ui/react-native-component-library.git`
- `git checkout feature/blui-3310-user-menu-within-a-header-bug`
- `yarn start:storybook`
- navigate to UserMenu "within a header" story and observe that the header renders on one line instead of 2
