### PR TITLE
Add support for statusBarTranslucent prop for Modal used in UserMenu

### DIFF
--- a/components/src/core/user-menu/bottom-sheet.tsx
+++ b/components/src/core/user-menu/bottom-sheet.tsx
@@ -15,8 +15,6 @@ type BottomSheetProps = {
         root?: ViewStyle;
         background?: ViewStyle;
     };
-    /** Make the status bar translucent */
-    statusBarTranslucent?: boolean;
 };
 
 const useStyles = (
@@ -42,7 +40,7 @@ const useStyles = (
  * a bottom sheet that appears from the bottom of the screen.
  */
 export const BottomSheet: React.FC<BottomSheetProps> = (props) => {
-    const { show, children, onClose, statusBarTranslucent, styles = {} } = props;
+    const { show, children, onClose, styles = {} } = props;
     const theme = useTheme();
     const defaultStyles = useStyles(theme, props);
 
@@ -52,8 +50,8 @@ export const BottomSheet: React.FC<BottomSheetProps> = (props) => {
             backdropOpacity={0.5}
             onBackdropPress={onClose}
             supportedOrientations={['portrait', 'landscape']}
-            statusBarTranslucent={statusBarTranslucent}
             style={[defaultStyles.root, styles.root]}
+            statusBarTranslucent
         >
             <SafeAreaView style={[defaultStyles.background, styles.background]}>{children}</SafeAreaView>
         </Modal>

--- a/components/src/core/user-menu/bottom-sheet.tsx
+++ b/components/src/core/user-menu/bottom-sheet.tsx
@@ -15,6 +15,8 @@ type BottomSheetProps = {
         root?: ViewStyle;
         background?: ViewStyle;
     };
+    /** Make the status bar translucent */
+    statusBarTranslucent?: boolean;
 };
 
 const useStyles = (
@@ -40,7 +42,7 @@ const useStyles = (
  * a bottom sheet that appears from the bottom of the screen.
  */
 export const BottomSheet: React.FC<BottomSheetProps> = (props) => {
-    const { show, children, onClose, styles = {} } = props;
+    const { show, children, onClose, statusBarTranslucent, styles = {} } = props;
     const theme = useTheme();
     const defaultStyles = useStyles(theme, props);
 
@@ -50,6 +52,7 @@ export const BottomSheet: React.FC<BottomSheetProps> = (props) => {
             backdropOpacity={0.5}
             onBackdropPress={onClose}
             supportedOrientations={['portrait', 'landscape']}
+            statusBarTranslucent={statusBarTranslucent}
             style={[defaultStyles.root, styles.root]}
         >
             <SafeAreaView style={[defaultStyles.background, styles.background]}>{children}</SafeAreaView>

--- a/components/src/core/user-menu/user-menu.tsx
+++ b/components/src/core/user-menu/user-menu.tsx
@@ -32,8 +32,6 @@ export type UserMenuProps = {
      * Theme value overrides specific to this component.
      */
     theme?: $DeepPartial<ReactNativePaper.Theme>;
-    /** Make the status bar translucent */
-    statusBarTranslucent?: boolean
 };
 
 const useStyles = (
@@ -75,7 +73,6 @@ export const UserMenu: React.FC<UserMenuProps> = (props) => {
         menuSubtitle,
         menuItems,
         styles = {},
-        statusBarTranslucent
     } = props;
     const avatarSize = avatar.props.size || 40;
     const [showBottomSheet, setShowBottomSheet] = useState(false);
@@ -178,7 +175,6 @@ export const UserMenu: React.FC<UserMenuProps> = (props) => {
                 backgroundColor={backgroundColor}
                 onClose={(): void => closeMenu()}
                 styles={{ root: styles.bottomsheet }}
-                statusBarTranslucent={statusBarTranslucent}
             >
                 {getMenu()}
             </BottomSheet>

--- a/components/src/core/user-menu/user-menu.tsx
+++ b/components/src/core/user-menu/user-menu.tsx
@@ -32,6 +32,8 @@ export type UserMenuProps = {
      * Theme value overrides specific to this component.
      */
     theme?: $DeepPartial<ReactNativePaper.Theme>;
+    /** Make the status bar translucent */
+    statusBarTranslucent?: boolean
 };
 
 const useStyles = (
@@ -73,6 +75,7 @@ export const UserMenu: React.FC<UserMenuProps> = (props) => {
         menuSubtitle,
         menuItems,
         styles = {},
+        statusBarTranslucent
     } = props;
     const avatarSize = avatar.props.size || 40;
     const [showBottomSheet, setShowBottomSheet] = useState(false);
@@ -175,6 +178,7 @@ export const UserMenu: React.FC<UserMenuProps> = (props) => {
                 backgroundColor={backgroundColor}
                 onClose={(): void => closeMenu()}
                 styles={{ root: styles.bottomsheet }}
+                statusBarTranslucent={statusBarTranslucent}
             >
                 {getMenu()}
             </BottomSheet>


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Add possibility to specify `statusBarTranslucent` boolean prop for UserMenu and pass it down to `Modal` component from `react-native-modal` library

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
I have the case in my Eaton app, where there is an image rendered in the status bar. The `UserMenu` component looks pretty ugly without the dark modal overlay covering the status bar. 
It can be resolved by setting `statusBarTranslucent={true}` in the Modal component. 

See: 
| Before   |      After      |  
|----------|:-------------:|
| <img width="400" alt="Screenshot 2022-12-21 at 13 14 58" src="https://user-images.githubusercontent.com/102028064/208907469-6b18e2e6-57cf-49ea-9666-ef121bca7fd1.png"> | <img width="400" alt="Screenshot 2022-12-21 at 13 15 20" src="https://user-images.githubusercontent.com/102028064/208907672-1402dae6-2847-4a36-af93-9817d4457107.png"> | 
